### PR TITLE
Fix: Unexpected input(s) 'body-filepath'

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In your workflow, to create a new discussion, include a step like this:
 ```yaml
     - name: Create a new GitHub Discussion
       id: create-discussion
-      uses: abirismyname/create-discussion@v1.x
+      uses: abirismyname/create-discussion@main
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
       with:


### PR DESCRIPTION
The v1.x branch has 99 commits behind the main branch.

And it doesn't support 'body-filepath' input.

`Warning: Unexpected input(s) 'body-filepath', valid inputs are ['title', 'body', 'repository-id', 'category-id']`

`Error: TypeError: Cannot read properties of null (reading 'id')`