### PR TITLE
Fetch Repository ID and Category ID on behalf of user

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -16,23 +16,21 @@ jobs:
       - uses: actions/checkout@v4
       - name: Generate new discussion
         id: create-discussion
-        uses: abirismyname/create-discussion@v1.2.0
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+        uses: abirismyname/create-discussion@v1.2.0 
         with:
           title: "New Discussion ${{ env.DATE }} in General"
           body: |
             Let's Discuss!
-          repository-id: 'R_kgDOG-yfvw'
-          category-id: 'DIC_kwDOG-yfv84CRQpR' 
+          repository-name: abirismyname/create-discussion
+          category-name: General
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate new discussion using file
         id: create-discussion-with-file
-        uses: abirismyname/create-discussion@v2.0.0
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+        uses: abirismyname/create-discussion@v2.0.0   
         with:
           title: "New Discussion ${{ env.DATE }} in General"
           body-filepath: 'zen.txt'
           repository-id: 'R_kgDOG-yfvw'
           category-id: 'DIC_kwDOG-yfv84CRQpR'           
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,35 +15,70 @@ In your workflow, to create a new discussion, include a step like this:
 ```yaml
     - name: Create a new GitHub Discussion
       id: create-discussion
-      uses: abirismyname/create-discussion@v1.x
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+      uses: abirismyname/create-discussion@main   
       with:
         title: Feelings
         body: |
           Let's talk!
-        repository-id: ${{ secrets.REPO_ID }}
-        category-id: ${{ secrets.CAT_ID }}  
+        category-name: Your Category              #optional, defaults to "General"
+        repository-name: owner/repo               #optional, defaults to the current repository
+        github-token: ${{ secrets.GITHUB_TOKEN }} 
+```
+
+If you know the `repository-id` and `category-id`, you can use them directly to create a discussion, which will speed things up slightly:
+
+```yaml
+    - name: Create a new GitHub Discussion
+      id: create-discussion
+      uses: abirismyname/create-discussion@main   
+      with:
+        title: Feelings
+        body: |
+          Let's talk!
+        repository-id: R_asdf1234
+        category-id: DIC_asdf1234
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The Action returns the `discussion-id` and `discussion-url` as outputs, which you can use in subsequent steps. For example, to print the discussion URL and ID:
+
+```yaml
+    - name: Create a new GitHub Discussion
+      id: create-discussion
+      uses: abirismyname/create-discussion@main   
+      with:
+        title: Feelings
+        body: |
+          Let's talk!
+        repository-id: R_asdf1234
+        category-id: DAC_asdf1234
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Print discussion url and id
       run: |
         echo discussion-id: ${{steps.create-discussion.outputs.discussion-id}} 
-        echo discussion-url: ${{steps.create-discussion.outputs.discussion-url}}             
+        echo discussion-url: ${{steps.create-discussion.outputs.discussion-url}}
 ```
 
 ## Inputs
 
-The following inputs are _required_:
+The Action accepts the following inputs:
 
-- `title`: The title of the discussion
-- `body`: The body of the discussion
-- `body-filepath`: The path to a file containing the body of the new discussion (takes precedence over `body`).**
+- `title`: The title of the discussion (Required)
+- `body`: The body of the discussion (Required, if `body-filepath` is not provided)
+- `body-filepath`: The path to a file containing the body of the new discussion (Required, if `body` is not provided. Takes precedence over `body`).
 - `repository-id`: The ID of the repository for the new discussion
-- `category-id`: The ID of the category for the new discussion. 
+- `category-id`: The ID of the category for the new discussion.
+- `repository-name`: The name of the repository (owner/repo) for the new discussion (Optional, defaults to the current repository)
+- `category-name`: The name of the category for the new discussion (Optional, defaults to "General" if the category-id is not provided)
+- `github-token`: The GitHub token to use for authentication (Required, unless `GH_TOKEN` is passed as an `env` variable).
 
-** If you are using `body-filepath` be sure to add a `actions/checkout` action before this action in the workflow to make sure the file exists in the action workspace.
+Note: If you are using `body-filepath` be sure to add a `actions/checkout` action before this action in the workflow to make sure the file exists in the action workspace.
 
 ### Obtaining the `repository-id` and `category-id`
+
 You can find `repository-id` and `category-id` using [GitHub's GraphQL Explorer](https://docs.github.com/en/graphql/overview/explorer). Replace `<REPO_NAME>` and `<REPO_OWNER>` with the repo you want to update.
+
 ```graphql
 query MyQuery {
   repository(name: "<REPO_NAME>", owner: "<REPO_OWNER>") {

--- a/__tests__/discussion.test.ts
+++ b/__tests__/discussion.test.ts
@@ -1,6 +1,7 @@
 process.env.GH_TOKEN = "123";
 
 import { Discussion } from "../lib/discussion";
+import { octokit } from "../lib/octokit";
 
 describe("Discussion", () => {
   describe("create", () => {
@@ -11,14 +12,14 @@ describe("Discussion", () => {
         "Discussion Title",
         "Discussion body text",
       );
-      discussion.octokit.graphql = jest.fn().mockResolvedValue({
+      octokit.graphql = jest.fn().mockResolvedValue({
         createDiscussion: {
           discussion: {
             id: "123",
             url: "https://example.com/discussion/123",
           },
         },
-      }) as unknown as typeof discussion.octokit.graphql;
+      }) as unknown as typeof octokit.graphql;
       await discussion.save();
 
       expect(discussion.id).toEqual("123");

--- a/__tests__/repository.test.ts
+++ b/__tests__/repository.test.ts
@@ -49,7 +49,7 @@ describe("Repository", () => {
     expect(repository.categories).toEqual(mockCategories);
     expect(octokit.graphql).toHaveBeenCalledWith(
       expect.stringContaining("query RepositoryCategories"),
-      { repositoryId: "" },
+      { name: mockName, owner: mockOwner },
     );
   });
 
@@ -79,7 +79,7 @@ describe("Repository", () => {
     expect(categoryId).toBe("cat-1");
     expect(octokit.graphql).toHaveBeenCalledWith(
       expect.stringContaining("query RepositoryCategories"),
-      { repositoryId: repository.id },
+      { name: mockName, owner: mockOwner },
     );
   });
 });

--- a/__tests__/repository.test.ts
+++ b/__tests__/repository.test.ts
@@ -1,0 +1,85 @@
+import { Repository } from "../lib/repository";
+import { octokit } from "../lib/octokit";
+
+jest.mock("../lib/octokit", () => ({
+  octokit: {
+    graphql: jest.fn(),
+  },
+}));
+
+describe("Repository", () => {
+  const mockOwner = "test-owner";
+  const mockName = "test-repo";
+  const mockRepoId = "repo-id-123";
+  const mockCategories = [
+    { id: "cat-1", name: "General" },
+    { id: "cat-2", name: "Announcements" },
+  ];
+
+  let repository: Repository;
+
+  beforeEach(() => {
+    repository = new Repository(`${mockOwner}/${mockName}`);
+    jest.clearAllMocks();
+  });
+
+  test("getId retrieves and sets the repository ID", async () => {
+    (octokit.graphql as unknown as jest.Mock).mockResolvedValue({
+      repository: { id: mockRepoId },
+    });
+
+    const id = await repository.getId();
+
+    expect(id).toBe(mockRepoId);
+    expect(repository.id).toBe(mockRepoId);
+    expect(octokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining("query RepositoryId"),
+      { owner: mockOwner, name: mockName },
+    );
+  });
+
+  test("getCategories retrieves and sets discussion categories", async () => {
+    (octokit.graphql as unknown as jest.Mock).mockResolvedValue({
+      repository: { discussionCategories: { nodes: mockCategories } },
+    });
+
+    const categories = await repository.getCategories();
+
+    expect(categories).toEqual(mockCategories);
+    expect(repository.categories).toEqual(mockCategories);
+    expect(octokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining("query RepositoryCategories"),
+      { repositoryId: "" },
+    );
+  });
+
+  test("getCategoryId retrieves the ID of a specific category", async () => {
+    repository.categories = mockCategories;
+
+    const categoryId = await repository.getCategoryId("General");
+
+    expect(categoryId).toBe("cat-1");
+  });
+
+  test("getCategoryId throws an error if the category is not found", async () => {
+    repository.categories = mockCategories;
+
+    await expect(repository.getCategoryId("Nonexistent")).rejects.toThrow(
+      'Category "Nonexistent" not found',
+    );
+  });
+
+  test("getCategoryId fetches categories if not already loaded", async () => {
+    (octokit.graphql as unknown as jest.Mock).mockResolvedValue({
+      repository: { discussionCategories: { nodes: mockCategories } },
+    });
+
+    const categoryId = await repository.getCategoryId("General");
+
+    expect(categoryId).toBe("cat-1");
+    expect(octokit.graphql).toHaveBeenCalledWith(
+      expect.stringContaining("query RepositoryCategories"),
+      { repositoryId: repository.id },
+    );
+  });
+});

--- a/action.yml
+++ b/action.yml
@@ -16,11 +16,22 @@ inputs:
   repository-id:
     description: |
       The ID of a repository in which to create the discussion.
-    required: true
+    required: false
   category-id:
     description: |
       The ID of a `DiscussionCategory` within this repository.
-    required: true
+    required: false
+  repository-name:
+    description: |
+      The name and owner of the repository in which to create the discussion (e.g., github/octocat).
+      If not provided, the action will use the repository that the Action is running in.
+    required: false
+    default: ${{ github.repository }}
+  category-name:
+    description: |
+      The name of the discussion category in which to create the discussion (defaults to 'General').
+    required: false
+    default: 'General'
   github-token:
     description: |
       A GitHub token with the necessary permissions to create a discussion.

--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,43 @@
 import * as core from "@actions/core";
 import { getInput } from "@actions/core";
 import fs from "fs";
-import { Discussion } from "./lib/discussion.js";
+import { Discussion } from "./lib/discussion";
+import { Repository } from "./lib/repository";
+
+function getRepo(): Repository {
+  const repository = getInput("repository-name", { required: true });
+  return new Repository(repository);
+}
+
+async function getRepositoryId(): Promise<string> {
+  const repositoryId = getInput("repository-id", { required: false });
+  if (repositoryId !== "") {
+    return repositoryId;
+  }
+
+  const repo = getRepo();
+  return await repo.getId();
+}
+
+async function getCategoryId(): Promise<string> {
+  const categoryId = getInput("category-id", { required: false });
+  if (categoryId !== "") {
+    return categoryId;
+  }
+
+  const categoryName = getInput("category-name", { required: false });
+  if (categoryName === "") {
+    throw new Error("Either category-id or category-name must be set");
+  }
+
+  const repo = getRepo();
+  const categories = await repo.getCategories();
+  return repo.getCategoryId(categoryName);
+}
 
 export default async function run(): Promise<void> {
-  const repositoryId = getInput("repository-id", { required: true });
-  const categoryId = getInput("category-id", { required: true });
+  const repositoryId = await getRepositoryId();
+  const categoryId = await getCategoryId();
   const title = getInput("title", { required: true });
   let body = getInput("body");
   const body_filepath = getInput("body-filepath");

--- a/lib/discussion.ts
+++ b/lib/discussion.ts
@@ -1,5 +1,5 @@
-import { getInput, info } from "@actions/core";
-import { getOctokit } from "@actions/github";
+import { info } from "@actions/core";
+import { octokit } from "./octokit";
 import type { GraphQlQueryResponseData } from "@octokit/graphql";
 
 const createDiscussionMutation = `
@@ -33,7 +33,6 @@ export class Discussion {
   body: string;
   id: string;
   url: string;
-  octokit = getOctokit(getInput("github-token") || process.env.GH_TOKEN);
 
   constructor(
     repositoryId: string,
@@ -48,7 +47,7 @@ export class Discussion {
   }
 
   async save(): Promise<void> {
-    const response: GraphQlQueryResponseData = await this.octokit.graphql(
+    const response: GraphQlQueryResponseData = await octokit.graphql(
       createDiscussionMutation,
       {
         repositoryId: this.repositoryId,

--- a/lib/octokit.ts
+++ b/lib/octokit.ts
@@ -1,0 +1,10 @@
+import { getInput } from "@actions/core";
+import { getOctokit } from "@actions/github";
+
+const token = getInput("github-token") || process.env.GH_TOKEN;
+
+if (token == "") {
+  throw new Error("Either github-token (with) or GH_TOKEN (env) must be set");
+}
+
+export const octokit = getOctokit(token);

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -1,0 +1,88 @@
+import { info } from "@actions/core";
+import { octokit } from "./octokit";
+import type { GraphQlQueryResponseData } from "@octokit/graphql";
+
+export type Category = {
+  id: string;
+  name: string;
+};
+
+export class Repository {
+  owner: string;
+  name: string;
+  id: string;
+  categories: Category[];
+
+  constructor(nwo: string) {
+    const [owner, name] = nwo.split("/");
+    if (!owner || !name) {
+      throw new Error(`Invalid repository name: ${nwo}`);
+    }
+
+    this.owner = owner;
+    this.name = name;
+    this.id = "";
+    this.categories = [];
+  }
+
+  async getId(): Promise<string> {
+    info(`Fetching repository ID for ${this.owner}/${this.name}`);
+    const response: GraphQlQueryResponseData = await octokit.graphql(
+      `query RepositoryId($owner: String!, $name: String!) {
+        repository(owner: $owner, name: $name) {
+          id
+        }
+      }`,
+      {
+        owner: this.owner,
+        name: this.name,
+      },
+    );
+
+    this.id = response.repository.id;
+    info(`Repository ID retrieved: ${this.id}`);
+    return this.id;
+  }
+
+  async getCategories(): Promise<Category[]> {
+    info(
+      `Fetching discussion categories for repository: ${this.owner}/${this.name}`,
+    );
+    const response: GraphQlQueryResponseData = await octokit.graphql(
+      `query RepositoryCategories($name: String!, $owner: String!) {
+        repository(owner: $owner, name: $name) {
+          discussionCategories(first: 100) {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      }`,
+      {
+        owner: this.owner,
+        name: this.name,
+      },
+    );
+
+    this.categories = response.repository.discussionCategories.nodes;
+    return this.categories;
+  }
+
+  async getCategoryId(categoryName: string): Promise<string> {
+    if (this.categories.length === 0) {
+      await this.getCategories();
+    }
+
+    const category = this.categories.find((cat) => cat.name === categoryName);
+    if (!category) {
+      info(
+        `Available categories: ${this.categories.map((cat) => cat.name).join(", ")}`,
+      );
+      throw new Error(`Category "${categoryName}" not found`);
+    }
+
+    info(`Category "${categoryName}" found with ID: ${category.id}`);
+    return category.id;
+  }
+}


### PR DESCRIPTION
This PR makes it so that the user doesn't have to manually fetch the Repository ID and Category ID. Now, the minimal use is:

```yml
    - name: Create a new GitHub Discussion
      id: create-discussion
      uses: abirismyname/create-discussion@main   
      with:
        title: Feelings
        body: |
          Let's talk!
        github-token: ${{ secrets.GITHUB_TOKEN }} 
```

Which would default to the `General` category in the current repository. `category-name` and `repository-name` can also be passed explicitly.

To accomplish this, I introduced a new Repository class to fetch the repository ID and lookup the category ID. As a result, I moved the `getOctokit` call to its own file so that it can be shared between the Repository and Discussion classes.

There should be no breaking changes for existing users.

You can see a [working example](https://github.com/benbalter/create-discussion/actions/runs/13975199404/job/39127290468) using [this workflow](https://github.com/benbalter/create-discussion/blob/main/.github/workflows/example.yml)